### PR TITLE
Tom bug profits table

### DIFF
--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -86,7 +86,7 @@ const PagedProfitsTable = () => {
 
 
     return (
-        <div style={{ display: "inline-block"}}>
+        <div style={{ display: "inline-block"}} data-testid={`${testId}-style-inline`}>
             <p>Page: {selectedPage + 1}</p>
             <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
             <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>

--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -86,7 +86,7 @@ const PagedProfitsTable = () => {
 
 
     return (
-        <>
+        <div style={{ display: "inline-block"}}>
             <p>Page: {selectedPage + 1}</p>
             <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
             <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
@@ -95,9 +95,8 @@ const PagedProfitsTable = () => {
                 columns={columns}
                 testid={testid}
                 initialState={{ sortBy: sortees }}
-
             />
-        </>
+        </div>
     );
 }; 
 

--- a/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
@@ -195,6 +195,25 @@ describe("PagedProfitsTable tests", () => {
 
 
   });
+  test("renders table with correct layout", async () => {
+    // Mock API response
+    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.onePage);
 
+    // Render the component
+    render(
+        <QueryClientProvider client={queryClient}>
+            <MemoryRouter>
+                <PagedProfitsTable />
+            </MemoryRouter>
+        </QueryClientProvider>
+    );
 
+    // Ensure the element with the specified data-testid is rendered
+    await waitFor(() => {
+        const tableWrapper = screen.getByTestId("PagedProfitsTable-style-inline");
+        expect(tableWrapper).toHaveStyle("display: inline-block");
     });
+  });
+
+
+});


### PR DESCRIPTION
## Overview
The profit table does not have any whitespace anymore, take up the whole frame.

## Screenshots (Optional)
<img width="1304" alt="Screenshot 2024-11-15 at 21 35 25" src="https://github.com/user-attachments/assets/6940d0ca-8e9c-4821-948c-ec2e07272e55">

## Validation (Optional)
1. Download this branch.
2. Run the project.
3. Go to profit table.

## Tests
<!--Add any additional tests or required tests-->
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #3 
