### PR TITLE
Alec - Fixed Leaderboard sorting by total wealth

### DIFF
--- a/frontend/src/main/components/Leaderboard/LeaderboardTable.js
+++ b/frontend/src/main/components/Leaderboard/LeaderboardTable.js
@@ -18,12 +18,9 @@ export default function LeaderboardTable({ leaderboardUsers }) {
         },
         {
             Header: "Total Wealth",
-            id: "totalWealth",
-            accessor: (row, _rowIndex) => {
-                return USD.format(row.totalWealth);
-            },
+            accessor: "totalWealth",
             Cell: (props) => {
-                return <div style={{ textAlign: "right" }}>{props.value}</div>;
+                return <div style={{ textAlign: "right" }}>{(USD.format(props.value))}</div>;
             },
         },
         {


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
Fixes the leaderboard sorting by total wealth.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
Previously, the leaderboard would incorrectly sort by wealth, and would place any monetary value less than 1000 over/under ones greater, depending on the sort order. Screenshots of the issue are as follows:
<img width="682" alt="image" src="https://github.com/user-attachments/assets/8040b518-a1c0-42eb-8e7f-ff692635e1fb">
<img width="687" alt="image" src="https://github.com/user-attachments/assets/26e80b4c-4ffd-472d-82d5-b74f010bb1fb">
Fixed:
<img width="776" alt="image" src="https://github.com/user-attachments/assets/2452e416-2844-4896-bc8f-d9167055efee">
<img width="776" alt="image" src="https://github.com/user-attachments/assets/da1d6a14-8cc3-4a24-8998-5ab43be961b0">


## Feedback Request (Optional)
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->
Other dependencies on the total wealth value could be broken, as the accessor now uses the raw value.

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
Navigate to https://happycows-dev-alecsong222-leaderboardsortbytotalwealth.dokku-09.cs.ucsb.edu/leaderboard/1
Join test commons
View leaderboard
Sort by ascending and descending and confirm the sort is correct

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #8 
