### PR TITLE
ADD DB TABLE FOR COURSES IN THE BACKEND

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
@@ -1,0 +1,21 @@
+package edu.ucsb.cs156.happiercows.entities;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity(name = "courses")
+public class Courses {
+    @Id
+    private String courseMajor;
+    private Integer courseNumber;
+    private String courseName;    
+}

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
@@ -15,7 +15,7 @@ import javax.persistence.*;
 @Entity(name = "courses")
 public class Courses {
     @Id
-    private String courseMajor;
+    private String subjectArea;
     private Integer courseNumber;
     private String courseName;    
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
@@ -24,5 +24,4 @@ public class Courses {
     private String term;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private String githubOrg;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
@@ -15,6 +15,9 @@ import javax.persistence.*;
 @Entity(name = "courses")
 public class Courses {
     @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    
     private String subjectArea;
     private Integer courseNumber;
     private String courseName;    

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Courses.java
@@ -5,8 +5,9 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.*;
+import java.time.LocalDateTime;
 
+import javax.persistence.*;
 
 @Data
 @AllArgsConstructor
@@ -17,8 +18,11 @@ public class Courses {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-    
-    private String subjectArea;
-    private Integer courseNumber;
-    private String courseName;    
+
+    private String name;
+    private String school;
+    private String term;
+    private LocalDateTime startDate;
+    private LocalDateTime endDate;
+    private String githubOrg;
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/CoursesRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/CoursesRepository.java
@@ -1,0 +1,11 @@
+package edu.ucsb.cs156.happiercows.repositories;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.stereotype.Repository;
+
+import edu.ucsb.cs156.happiercows.entities.Courses;
+
+@Repository
+public interface CoursesRepository extends CrudRepository<Courses, Long>{
+    
+}

--- a/src/main/resources/db/migration/changes/Courses.json
+++ b/src/main/resources/db/migration/changes/Courses.json
@@ -62,8 +62,7 @@
                     "name": "END_DATE",
                     "type": "TIMESTAMP"
                   }
-                },
-                
+                }
               ],
               "tableName": "COURSES"
             }

--- a/src/main/resources/db/migration/changes/Courses.json
+++ b/src/main/resources/db/migration/changes/Courses.json
@@ -41,7 +41,7 @@
                   },
                   {
                     "column": {
-                      "name": "COURSENUMBER",
+                      "name": "COURSE_NUMBER",
                       "type": "INT"
                     }
                   },

--- a/src/main/resources/db/migration/changes/Courses.json
+++ b/src/main/resources/db/migration/changes/Courses.json
@@ -1,63 +1,80 @@
 {
-    "databaseChangeLog": [
-      {
-        "changeSet": {
-          "id": "CoursesTable-1",
-          "author": "TomShangguan",
-          "preConditions": [
-            {
-              "onFail": "MARK_RAN"
-            },
-            {
-              "not": [
+  "databaseChangeLog": [
+    {
+      "changeSet": {
+        "id": "CoursesTable-2",
+        "author": "TomShangguan",
+        "preConditions": [
+          {
+            "onFail": "MARK_RAN"
+          },
+          {
+            "not": [
+              {
+                "tableExists": {
+                  "tableName": "COURSES"
+                }
+              }
+            ]
+          }
+        ],
+        "changes": [
+          {
+            "createTable": {
+              "columns": [
                 {
-                  "tableExists": {
-                    "tableName": "COURSES"
+                  "column": {
+                    "autoIncrement": true,
+                    "constraints": {
+                      "primaryKey": true,
+                      "primaryKeyName": "COURSES_PK"
+                    },
+                    "name": "ID",
+                    "type": "BIGINT"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "NAME",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "SCHOOL",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "TERM",
+                    "type": "VARCHAR(255)"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "START_DATE",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "END_DATE",
+                    "type": "TIMESTAMP"
+                  }
+                },
+                {
+                  "column": {
+                    "name": "GITHUB_ORG",
+                    "type": "VARCHAR(255)"
                   }
                 }
-              ]
+              ],
+              "tableName": "COURSES"
             }
-          ],
-          "changes": [
-            {
-              "createTable": {
-                "columns": [
-                  {
-                    "column": {
-                      "autoIncrement": true,
-                      "constraints": {
-                        "primaryKey": true,
-                        "primaryKeyName": "COURSES_PK"
-                      },
-                      "name": "ID",
-                      "type": "BIGINT"
-                    }
-                  },
-                  {
-                    "column": {
-                      "name": "SUBJECT_AREA",
-                      "type": "VARCHAR(255)"
-                    }
-                  },
-                  {
-                    "column": {
-                      "name": "COURSE_NUMBER",
-                      "type": "INT"
-                    }
-                  },
-                  {
-                    "column": {
-                      "name": "COURSE_NAME",
-                      "type": "VARCHAR(255)"
-                    }
-                  }
-                ],
-                "tableName": "COURSES"
-              }
-            }
-          ]
-        }
+          }
+        ]
       }
-    ]
-  }
-  
+    }
+  ]
+}

--- a/src/main/resources/db/migration/changes/Courses.json
+++ b/src/main/resources/db/migration/changes/Courses.json
@@ -35,7 +35,7 @@
                   },
                   {
                     "column": {
-                      "name": "COURSEMAJOR",
+                      "name": "SUBJECT_AREA",
                       "type": "VARCHAR(255)"
                     }
                   },

--- a/src/main/resources/db/migration/changes/Courses.json
+++ b/src/main/resources/db/migration/changes/Courses.json
@@ -1,0 +1,63 @@
+{
+    "databaseChangeLog": [
+      {
+        "changeSet": {
+          "id": "CoursesTable-1",
+          "author": "TomShangguan",
+          "preConditions": [
+            {
+              "onFail": "MARK_RAN"
+            },
+            {
+              "not": [
+                {
+                  "tableExists": {
+                    "tableName": "COURSES"
+                  }
+                }
+              ]
+            }
+          ],
+          "changes": [
+            {
+              "createTable": {
+                "columns": [
+                  {
+                    "column": {
+                      "autoIncrement": true,
+                      "constraints": {
+                        "primaryKey": true,
+                        "primaryKeyName": "COURSES_PK"
+                      },
+                      "name": "ID",
+                      "type": "BIGINT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COURSEMAJOR",
+                      "type": "VARCHAR(255)"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COURSENUMBER",
+                      "type": "INT"
+                    }
+                  },
+                  {
+                    "column": {
+                      "name": "COURSENAME",
+                      "type": "VARCHAR(255)"
+                    }
+                  }
+                ],
+                "tableName": "COURSES"
+              }
+            }
+          ]
+        }
+      }
+    ]
+  }
+  

--- a/src/main/resources/db/migration/changes/Courses.json
+++ b/src/main/resources/db/migration/changes/Courses.json
@@ -63,12 +63,7 @@
                     "type": "TIMESTAMP"
                   }
                 },
-                {
-                  "column": {
-                    "name": "GITHUB_ORG",
-                    "type": "VARCHAR(255)"
-                  }
-                }
+                
               ],
               "tableName": "COURSES"
             }

--- a/src/main/resources/db/migration/changes/Courses.json
+++ b/src/main/resources/db/migration/changes/Courses.json
@@ -47,7 +47,7 @@
                   },
                   {
                     "column": {
-                      "name": "COURSENAME",
+                      "name": "COURSE_NAME",
                       "type": "VARCHAR(255)"
                     }
                   }


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
Add database files for courses in the backend for happycow. Including migration file, entity, and repository file. Deployed on dokku and can see the table in the database.

## Screenshots (Optional)
<img width="1219" alt="Screenshot 2024-11-20 at 21 31 38" src="https://github.com/user-attachments/assets/3faa7cdf-663e-4c1d-9e2f-fb9f92f58270">




## Linked Issues
<!--Issues related to the PR-->
Closes #16 
