### PR TITLE
Fixed alignment in the profit table so numeric values are right aligned, rather than left

### DIFF
--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -54,7 +54,9 @@ const PagedProfitsTable = () => {
             {
                 Header: "Profit",
                 accessor: "amount",
-                Cell: ({value}) => `$${value.toFixed(2)}`,
+                Cell: ({value}) => {
+                    return <div style={{ textAlign: "right" }}>${value.toFixed(2)}</div>;
+                }
             },
             {
                 Header: "Date",
@@ -64,11 +66,16 @@ const PagedProfitsTable = () => {
             {
                 Header: "Health",
                 accessor: "avgCowHealth",
-                Cell: ({value}) => `${value.toFixed(2) + '%'}`
+                Cell: ({value}) => {
+                    return <div style={{ textAlign: "right" }}>{value.toFixed(2)}%</div>;
+                }
             },
             {
                 Header: "Cows",
                 accessor: "numCows",
+                Cell: (props) => {
+                    return <div style={{ textAlign: "right" }}>{props.value}</div>;
+                }
             },
         ];
 
@@ -95,7 +102,6 @@ const PagedProfitsTable = () => {
                 columns={columns}
                 testid={testid}
                 initialState={{ sortBy: sortees }}
-
             />
         </>
     );

--- a/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
@@ -20,7 +20,6 @@ describe("PagedProfitsTable tests", () => {
   });
 
 
-
   test("renders correct content", async () => {
 
     // arrange
@@ -195,6 +194,109 @@ describe("PagedProfitsTable tests", () => {
 
 
   });
+  // Add these new tests at the end, just before the final closing bracket
 
+  test("cells have correct right alignment styling", async () => {
+    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.onePage);
 
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
     });
+
+    // Check profit cell formatting and alignment
+    const profitCell = screen.getByTestId(`${testId}-cell-row-0-col-amount`);
+    expect(profitCell).toHaveTextContent("$110.00");
+    const profitStyle = window.getComputedStyle(profitCell);
+    expect(profitStyle.textAlign).toBe("right");
+
+    // Check health cell formatting and alignment
+    const healthCell = screen.getByTestId(`${testId}-cell-row-0-col-avgCowHealth`);
+    expect(healthCell).toHaveTextContent("100.00%");
+    const healthStyle = window.getComputedStyle(healthCell);
+    expect(healthStyle.textAlign).toBe("right");
+
+    // Check cows cell alignment
+    const cowsCell = screen.getByTestId(`${testId}-cell-row-0-col-numCows`);
+    expect(cowsCell).toHaveTextContent("5");
+    const cowsStyle = window.getComputedStyle(cowsCell);
+    expect(cowsStyle.textAlign).toBe("right");
+  });
+
+  test("profit cells maintain formatting with different values", async () => {
+    const modifiedData = {
+      ...pagedProfitsFixtures.onePage,
+      content: [{
+        ...pagedProfitsFixtures.onePage.content[0],
+        amount: 1234.5678,
+        avgCowHealth: 75.5555
+      }]
+    };
+
+    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, modifiedData);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+    const profitCell = screen.getByTestId(`${testId}-cell-row-0-col-amount`);
+    expect(profitCell).toHaveTextContent("$1,234.57");
+    
+    const healthCell = screen.getByTestId(`${testId}-cell-row-0-col-avgCowHealth`);
+    expect(healthCell).toHaveTextContent("75.56%");
+  });
+
+  test("cells maintain alignment with empty or zero values", async () => {
+    const modifiedData = {
+      ...pagedProfitsFixtures.onePage,
+      content: [{
+        ...pagedProfitsFixtures.onePage.content[0],
+        amount: 0,
+        avgCowHealth: 0,
+        numCows: 0
+      }]
+    };
+
+    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, modifiedData);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+    const profitCell = screen.getByTestId(`${testId}-cell-row-0-col-amount`);
+    expect(profitCell).toHaveTextContent("$0.00");
+    expect(window.getComputedStyle(profitCell).textAlign).toBe("right");
+
+    const healthCell = screen.getByTestId(`${testId}-cell-row-0-col-avgCowHealth`);
+    expect(healthCell).toHaveTextContent("0.00%");
+    expect(window.getComputedStyle(healthCell).textAlign).toBe("right");
+
+    const cowsCell = screen.getByTestId(`${testId}-cell-row-0-col-numCows`);
+    expect(cowsCell).toHaveTextContent("0");
+    expect(window.getComputedStyle(cowsCell).textAlign).toBe("right");
+  });
+});
+


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
This is a small PR which edits one file PagedProfitsTable.js. Dokku deployment: https://proj-happycows-f24-09-elijahelephant-dev.dokku-09.cs.ucsb.edu/

## Screenshots (Optional)
<img width="1549" alt="Screenshot 2024-11-21 at 5 36 51 PM" src="https://github.com/user-attachments/assets/31c3f48a-4985-405e-a9b2-c9a706118994">

## Future Possibilities (Optional)
I see there is a weird white space on the right side of the table and we could fix that. I get the same visual when looking on the production deployment but it could be specific to my display but I am not sure.

## Validation (Optional)
1. Download this branch.
2. Run the project.
3. Buy Cows
4. Milk the cows and then look at the profit table to see that the numbers are correctly aligned


## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #38
