### PR TITLE
Alec - Added test to verify correct Leaderboard sorting by total wealth

### DIFF
--- a/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
+++ b/frontend/src/tests/components/Leaderboard/LeaderboardTable.test.js
@@ -128,7 +128,7 @@ describe("LeaderboardTable tests", () => {
         ).toHaveTextContent("9");
     });
 
-    test("Total wealth is formatted correctly", () => {
+    test("Total wealth is formatted correctly", () => { 
         const currentUser = currentUserFixtures.adminUser;
 
         render(
@@ -153,6 +153,38 @@ describe("LeaderboardTable tests", () => {
         expect(screen.getAllByText("10")[0]).toHaveStyle("text-align: right;");
         expect(screen.getAllByText("9")[0]).toHaveStyle("text-align: right;");
     });
+
+    test("Correctly sorts by Total Wealth", () => {
+        const currentUser = currentUserFixtures.adminUser;
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <LeaderboardTable
+                        leaderboardUsers={leaderboardFixtures.fiveUserCommonsLB}
+                        currentUser={currentUser}
+                    />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        const wealthHeader = screen.getByText("Total Wealth");
+
+        //unsorted
+        const rowsUnsorted = screen.getAllByTestId(/LeaderboardTable-cell-row-\d+-col-totalWealth/).map(cell => cell.textContent);
+        expect(rowsUnsorted).toEqual(["$1,000.00", "$1,000.00", "$100,000.00", "$50.00", "$800.00"]);
+
+        //sorted by ascending
+        fireEvent.click(wealthHeader);
+        const rowsAscending = screen.getAllByTestId(/LeaderboardTable-cell-row-\d+-col-totalWealth/).map(cell => cell.textContent);
+        expect(rowsAscending).toEqual(["$50.00", "$800.00", "$1,000.00", "$1,000.00", "$100,000.00"]);
+
+        //sorted by descending
+        fireEvent.click(wealthHeader);
+        const rowsDescending = screen.getAllByTestId(/LeaderboardTable-cell-row-\d+-col-totalWealth/).map(cell => cell.textContent);
+        expect(rowsDescending).toEqual(["$100,000.00", "$1,000.00", "$1,000.00", "$800.00", "$50.00"]);
+    });
+
     test("Clicking on link navigates to the correct URL", () => {
         const currentUser = currentUserFixtures.adminUser;
 


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
This PR adds a test to LeaderboardTable.test.js to ensure that the leaderboard correctly sorts by total wealth after the fix that was pushed to main.
https://happycows-dev-alecsong222-leaderboardsortbytotalwealth.dokku-09.cs.ucsb.edu
Branch - https://github.com/ucsb-cs156-f24/proj-happycows-f24-09/tree/Alec-LeaderboardSortByTotalWealth

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
Before fix:
<img width="1493" alt="image" src="https://github.com/user-attachments/assets/40231506-36a3-4357-8036-a61ab0b448da">
After fix:
<img width="859" alt="image" src="https://github.com/user-attachments/assets/cc260db2-7fc5-4328-9a20-4d670fa7c21e">
<img width="1000" alt="image" src="https://github.com/user-attachments/assets/91f9807c-3a5c-4ca9-848a-fdcea216de4e">

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
Locally, use npm test and npx stryker run -m src/main/components/Leaderboard/LeaderboardTable.js and ensure that all tests pass and no mutations survive

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #56 

## PR Checklist
- [x] Commented code removed
- [x] PR deals with only one concern
- [x] PR Title is descriptive enough
- [x] PR description details what a user/dev will notice is different
- [x] No merge conflicts
- [x] Deployed and linked with Dokku deployment
- [x] New branch updated with main
- [x] PR is linked to a branch
- [x] PR is linked to an issue/ticket
- [x] Linked issue is in "In Review" column on Kanban board
- [x] PR is tagged with the Team's tag
- [x] All test cases pass
