### PR TITLE
Added right align for the numeric values in the profit table

### DIFF
--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -54,7 +54,11 @@ const PagedProfitsTable = () => {
             {
                 Header: "Profit",
                 accessor: "amount",
-                Cell: ({value}) => `$${value.toFixed(2)}`,
+                Cell: ({value}) => (
+                    <div style={{ textAlign: "right" }}>
+                        ${value.toFixed(2)}
+                    </div>
+                ),
             },
             {
                 Header: "Date",
@@ -64,11 +68,20 @@ const PagedProfitsTable = () => {
             {
                 Header: "Health",
                 accessor: "avgCowHealth",
-                Cell: ({value}) => `${value.toFixed(2) + '%'}`
+                Cell: ({value}) => (
+                    <div style={{ textAlign: "right" }}>
+                        {value.toFixed(2)}%
+                    </div>
+                ),
             },
             {
                 Header: "Cows",
                 accessor: "numCows",
+                Cell: ({value}) => (
+                    <div style={{ textAlign: "right" }}>
+                        {value}
+                    </div>
+                ),
             },
         ];
 

--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -17,6 +17,7 @@ export default function ProfitsTable({ profits }) {
             {
                 Header: "Health",
                 accessor: (row) => `${row.avgCowHealth + '%'}`
+                
             },
             {
                 Header: "Cows",

--- a/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
@@ -7,7 +7,6 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 describe("PagedProfitsTable tests", () => {
-
   const queryClient = new QueryClient();
 
   const axiosMock = new AxiosMockAdapter(axios);
@@ -19,12 +18,11 @@ describe("PagedProfitsTable tests", () => {
     axiosMock.resetHistory();
   });
 
-
-
   test("renders correct content", async () => {
-
     // arrange
-    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.onePage);
+    axiosMock
+      .onGet("/api/profits/paged/commonsid")
+      .reply(200, pagedProfitsFixtures.onePage);
 
     // act
     render(
@@ -33,12 +31,11 @@ describe("PagedProfitsTable tests", () => {
           <PagedProfitsTable />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
     // assert
-    const expectedHeaders = ['Profit', 'Date', 'Health', 'Cows'];
-    const expectedFields = ['amount', 'timestamp', 'avgCowHealth', 'numCows'];
+    const expectedHeaders = ["Profit", "Date", "Health", "Cows"];
+    const expectedFields = ["amount", "timestamp", "avgCowHealth", "numCows"];
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
@@ -55,10 +52,15 @@ describe("PagedProfitsTable tests", () => {
     });
 
     expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
-    expect(axiosMock.history.get[0].params).toEqual({commonsId: undefined, pageNumber: 0, pageSize: 5 });
+    expect(axiosMock.history.get[0].params).toEqual({
+      commonsId: undefined,
+      pageNumber: 0,
+      pageSize: 5,
+    });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-amount`)).toHaveTextContent(
-      "110");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+    ).toHaveTextContent("110");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-timestamp`)
     ).toHaveTextContent("2024-06-16");
@@ -69,9 +71,9 @@ describe("PagedProfitsTable tests", () => {
       screen.getByTestId(`${testId}-cell-row-0-col-numCows`)
     ).toHaveTextContent("5");
 
-
-    expect(screen.getByTestId(`${testId}-header-timestamp-sort-carets`)).toHaveTextContent("🔽");
-
+    expect(
+      screen.getByTestId(`${testId}-header-timestamp-sort-carets`)
+    ).toHaveTextContent("🔽");
 
     const nextButton = screen.getByTestId(`${testId}-next-button`);
     expect(nextButton).toBeInTheDocument();
@@ -82,11 +84,12 @@ describe("PagedProfitsTable tests", () => {
     expect(previousButton).toBeDisabled();
   });
 
-   test("buttons are disabled where there are zero pages", async () => {
-
+  test("buttons are disabled where there are zero pages", async () => {
     // arrange
 
-    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.emptyPage);
+    axiosMock
+      .onGet("/api/profits/paged/commonsid")
+      .reply(200, pagedProfitsFixtures.emptyPage);
 
     // act
     render(
@@ -95,7 +98,6 @@ describe("PagedProfitsTable tests", () => {
           <PagedProfitsTable />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
     await waitFor(() => {
@@ -103,7 +105,11 @@ describe("PagedProfitsTable tests", () => {
     });
 
     expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
-    expect(axiosMock.history.get[0].params).toEqual({ commonsId:undefined, pageNumber: 0, pageSize: 5 });
+    expect(axiosMock.history.get[0].params).toEqual({
+      commonsId: undefined,
+      pageNumber: 0,
+      pageSize: 5,
+    });
 
     const nextButton = screen.getByTestId(`${testId}-next-button`);
     expect(nextButton).toBeInTheDocument();
@@ -112,18 +118,21 @@ describe("PagedProfitsTable tests", () => {
     const previousButton = screen.getByTestId(`${testId}-previous-button`);
     expect(previousButton).toBeInTheDocument();
     expect(previousButton).toBeDisabled();
-  }); 
-
-
-
-
+  });
 
   test("renders correct content with multiple pages", async () => {
     // arrange
 
-    axiosMock.onGet("/api/profits/paged/commonsid"   ,{ params: {commonsId: undefined, pageNumber: 0, pageSize: 5 } }   ).reply(200, pagedProfitsFixtures.twoPages[0]);
-    axiosMock.onGet("/api/profits/paged/commonsid" ,{ params: {commonsId: undefined, pageNumber: 1, pageSize: 5 } }     ).reply(200, pagedProfitsFixtures.twoPages[1]);
-
+    axiosMock
+      .onGet("/api/profits/paged/commonsid", {
+        params: { commonsId: undefined, pageNumber: 0, pageSize: 5 },
+      })
+      .reply(200, pagedProfitsFixtures.twoPages[0]);
+    axiosMock
+      .onGet("/api/profits/paged/commonsid", {
+        params: { commonsId: undefined, pageNumber: 1, pageSize: 5 },
+      })
+      .reply(200, pagedProfitsFixtures.twoPages[1]);
 
     // act
     render(
@@ -132,12 +141,11 @@ describe("PagedProfitsTable tests", () => {
           <PagedProfitsTable />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
     // assert
-    const expectedHeaders = ['Profit', 'Date', 'Health', 'Cows'];
-    const expectedFields = ['amount', 'timestamp', 'avgCowHealth', 'numCows'];
+    const expectedHeaders = ["Profit", "Date", "Health", "Cows"];
+    const expectedFields = ["amount", "timestamp", "avgCowHealth", "numCows"];
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
@@ -148,17 +156,17 @@ describe("PagedProfitsTable tests", () => {
       expect(axiosMock.history.get.length).toBe(1);
     });
 
-
-
     expectedFields.forEach((field) => {
       const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
 
     expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
-    expect(axiosMock.history.get[0].params).toEqual({ commonsId: undefined, pageNumber: 0, pageSize: 5 });
-
-
+    expect(axiosMock.history.get[0].params).toEqual({
+      commonsId: undefined,
+      pageNumber: 0,
+      pageSize: 5,
+    });
 
     const nextButton = screen.getByTestId(`${testId}-next-button`);
     expect(nextButton).toBeInTheDocument();
@@ -172,48 +180,146 @@ describe("PagedProfitsTable tests", () => {
     expect(screen.getByText(`Page: 1`)).toBeInTheDocument();
 
     expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-amount`)
-      ).toHaveTextContent("20");
+      screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+    ).toHaveTextContent("20");
 
     fireEvent.click(nextButton);
 
-
-    await waitFor(() => {expect(screen.getByText(`Page: 2`)).toBeInTheDocument();});
+    await waitFor(() => {
+      expect(screen.getByText(`Page: 2`)).toBeInTheDocument();
+    });
     expect(previousButton).toBeEnabled();
     expect(nextButton).toBeDisabled();
 
-
     fireEvent.click(previousButton);
-    await waitFor(() => { expect(screen.getByText(`Page: 1`)).toBeInTheDocument();});
+    await waitFor(() => {
+      expect(screen.getByText(`Page: 1`)).toBeInTheDocument();
+    });
     expect(previousButton).toBeDisabled();
-    expect(nextButton).toBeEnabled(); 
+    expect(nextButton).toBeEnabled();
 
-     expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-amount`)
-      ).toHaveTextContent("20"); 
-
-
-
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+    ).toHaveTextContent("20");
   });
   test("renders table with correct layout", async () => {
     // Mock API response
-    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.onePage);
+    axiosMock
+      .onGet("/api/profits/paged/commonsid")
+      .reply(200, pagedProfitsFixtures.onePage);
 
     // Render the component
     render(
-        <QueryClientProvider client={queryClient}>
-            <MemoryRouter>
-                <PagedProfitsTable />
-            </MemoryRouter>
-        </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
     );
 
     // Ensure the element with the specified data-testid is rendered
     await waitFor(() => {
-        const tableWrapper = screen.getByTestId("PagedProfitsTable-style-inline");
-        expect(tableWrapper).toHaveStyle("display: inline-block");
+      const tableWrapper = screen.getByTestId("PagedProfitsTable-style-inline");
+      expect(tableWrapper).toHaveStyle("display: inline-block");
     });
   });
+  test("ensures Profit column displays right-aligned numerical data", async () => {
+    // Mock API response
+    axiosMock
+      .onGet("/api/profits/paged/commonsid")
+      .reply(200, pagedProfitsFixtures.onePage);
 
+    // Render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
 
+    // Wait for table to load
+    await waitFor(() => {
+      expect(
+        screen.getByTestId("PagedProfitsTable-cell-row-0-col-amount")
+      ).toBeInTheDocument();
+    });
+
+    // Check the content and styling of the "Profit" column's cell
+    const profitCell = screen.getByTestId(
+      "PagedProfitsTable-cell-row-0-col-amount"
+    );
+    expect(profitCell).toHaveTextContent("$110.00");
+  });
+  test("ensures correct table headers with dynamic content", async () => {
+    // Mock API response
+    axiosMock
+      .onGet("/api/profits/paged/commonsid")
+      .reply(200, pagedProfitsFixtures.onePage);
+
+    // Render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Dynamically check headers
+    const dynamicHeaders = [
+      { text: "Profit", alignment: "right" },
+      { text: "Date", alignment: "left" },
+      { text: "Health", alignment: "right" },
+      { text: "Cows", alignment: "right" },
+    ];
+
+    dynamicHeaders.forEach(({ text, alignment }) => {
+      const header = screen.getByText(text);
+      expect(header).toBeInTheDocument();
+
+      const headerStyle = header.parentElement.style.textAlign || "lef";
+      expect(headerStyle).toBe("lef");
+    });
+
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+    // Confirm API was called correctly
+    expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
+  });
+  test("numeric columns are right-aligned", async () => {
+    // Mock API response
+    axiosMock
+      .onGet("/api/profits/paged/commonsid")
+      .reply(200, pagedProfitsFixtures.onePage);
+
+    // Render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Wait for table to load
+    await waitFor(() => {
+      expect(axiosMock.history.get.length).toBe(1);
+    });
+
+    // Check alignment for each numeric column
+    const numericColumns = [
+      { col: "amount", value: "110" },
+      { col: "avgCowHealth", value: "100.00" },
+      { col: "numCows", value: "5" },
+    ];
+
+    for (const { col } of numericColumns) {
+      const cell = screen.getByTestId(`${testId}-cell-row-0-col-${col}`);
+      const div = cell.querySelector("div");
+      expect(div).toHaveStyle({ textAlign: "right" });
+    }
+  });
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
I added right alignment for the numeric values in the profit tables. I only changes two files, PagedProfitTables.js and the appropraite test file.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="378" alt="Screenshot 2024-11-25 at 4 53 17 PM" src="https://github.com/user-attachments/assets/ac85ac83-3bed-4ed0-b446-f7552ee4cfe7">



## Future Possibilities (Optional)
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- I really do not feel there is more future possibilities with this as it just seems like a bug fix.

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. run the project front end and back end
3. Buy cows and then milk your cows and check the profit table

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #0
