### PR TITLE
Alec - Full Mutation Coverage for ProfitsTable.js

### DIFF
--- a/frontend/src/tests/components/Commons/ProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/ProfitsTable.test.js
@@ -3,6 +3,11 @@ import ProfitsTable from "main/components/Commons/ProfitsTable";
 import profitsFixtures from "fixtures/profitsFixtures";
 
 describe("ProfitsTable tests", () => {
+    const testId = "ProfitsTable";
+
+    const expectedHeaders = ["Profit", "Date", "Health", "Cows"];
+    const expectedFields = ["Profit", "date", "Health", "numCows"];
+
     test("renders without crashing for 0 profits", () => {
         render(
             <ProfitsTable profits={[]} />
@@ -16,13 +21,38 @@ describe("ProfitsTable tests", () => {
         await waitFor(()=>{
             expect(screen.getByTestId("ProfitsTable-header-Profit") ).toBeInTheDocument();
         });
-
-        const expectedHeaders = [ "Profit", "Date", "Health", "Cows"];
     
         expectedHeaders.forEach((headerText) => {
           const header = screen.getByText(headerText);
           expect(header).toBeInTheDocument();
         });
 
+    });
+
+    test("renders table correctly with profits data", () => {
+        render(
+            <ProfitsTable profits={profitsFixtures.threeProfits} />
+        );
+        
+        expectedHeaders.forEach((headerText) => {
+            const header = screen.getByText(headerText);
+            expect(header).toBeInTheDocument();
+        });
+
+        expectedFields.forEach((field) => {
+            const fieldElement = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+            expect(fieldElement).toBeInTheDocument();
+        });
+
+        profitsFixtures.threeProfits.forEach((profit, rowIndex) => {
+            expect(screen.getByTestId(`${testId}-cell-row-${rowIndex}-col-Profit`))
+                .toHaveTextContent(`$${profit.amount.toFixed(2)}`);
+
+            expect(screen.getByTestId(`${testId}-cell-row-${rowIndex}-col-Health`))
+                .toHaveTextContent(`${profit.avgCowHealth}%`);
+
+            expect(screen.getByTestId(`${testId}-cell-row-${rowIndex}-col-numCows`))
+                .toHaveTextContent(profit.numCows.toString());
+        });
     });
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
This PR ensures full mutation coverage for ProfitsTable.js - the end user will not see anything, as ProfitsTable worked regardless on the frontend, but a Dokku deployment is included nonetheless.
https://happycows-dev-alecsong222-students.dokku-09.cs.ucsb.edu/
Branch - https://github.com/ucsb-cs156-f24/proj-happycows-f24-09/tree/Alec-ProfitsTableMutations

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="1044" alt="image" src="https://github.com/user-attachments/assets/adf9f080-9991-4dce-9ee3-e4523127501b">

## Feedback Request (Optional)
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->
The test that covers the mutations previously present renders and checks the table with threeProfits from profitsFixtures.js; however, everything but the date is checked for - there's some odd behavior where the date is not rendered whatsoever when testing, likely due to a bad accessor in ProfitsTable.js or a flaw in the newly written test, but the date shows correctly on the frontend regardless. Feedback on whether or not to include testing for this, which would require a fix to ProfitsTable.js directly and other affected areas, would be appreciated.

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
Deploy this branch locally and run: npx stryker run -m src/main/components/Commons/ProfitsTable.js
Ensure that all mutations are covered

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% (CommonsCard.js does not have full mutation coverage, which will be addressed in a separate ticket.
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #61 

## PR Checklist
- [x] Commented code removed
- [x] PR deals with only one concern
- [x] PR Title is descriptive enough
- [x] PR description details what a user/dev will notice is different
- [x] No merge conflicts
- [x] Deployed and linked with Dokku deployment
- [x] New branch updated with main
- [x] PR is linked to a branch
- [x] PR is linked to an issue/ticket
- [x] Linked issue is in "In Review" column on Kanban board
- [x] PR is tagged with the Team's tag
- [x] All test cases pass