### PR TITLE
Elijah - Fix right alignment in profit table on commons page #38

### DIFF
--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -54,7 +54,11 @@ const PagedProfitsTable = () => {
             {
                 Header: "Profit",
                 accessor: "amount",
-                Cell: ({value}) => `$${value.toFixed(2)}`,
+                Cell: ({value}) => (
+                    <div style={{ textAlign: "right" }}>
+                        ${value.toFixed(2)}
+                    </div>
+                ),
             },
             {
                 Header: "Date",
@@ -64,11 +68,20 @@ const PagedProfitsTable = () => {
             {
                 Header: "Health",
                 accessor: "avgCowHealth",
-                Cell: ({value}) => `${value.toFixed(2) + '%'}`
+                Cell: ({value}) => (
+                    <div style={{ textAlign: "right" }}>
+                        {value.toFixed(2)}%
+                    </div>
+                ),
             },
             {
                 Header: "Cows",
                 accessor: "numCows",
+                Cell: ({value}) => (
+                    <div style={{ textAlign: "right" }}>
+                        {value}
+                    </div>
+                ),
             },
         ];
 

--- a/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
@@ -7,7 +7,6 @@ import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
 describe("PagedProfitsTable tests", () => {
-
   const queryClient = new QueryClient();
 
   const axiosMock = new AxiosMockAdapter(axios);
@@ -19,12 +18,11 @@ describe("PagedProfitsTable tests", () => {
     axiosMock.resetHistory();
   });
 
-
-
   test("renders correct content", async () => {
-
     // arrange
-    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.onePage);
+    axiosMock
+      .onGet("/api/profits/paged/commonsid")
+      .reply(200, pagedProfitsFixtures.onePage);
 
     // act
     render(
@@ -33,12 +31,11 @@ describe("PagedProfitsTable tests", () => {
           <PagedProfitsTable />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
     // assert
-    const expectedHeaders = ['Profit', 'Date', 'Health', 'Cows'];
-    const expectedFields = ['amount', 'timestamp', 'avgCowHealth', 'numCows'];
+    const expectedHeaders = ["Profit", "Date", "Health", "Cows"];
+    const expectedFields = ["amount", "timestamp", "avgCowHealth", "numCows"];
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
@@ -55,10 +52,15 @@ describe("PagedProfitsTable tests", () => {
     });
 
     expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
-    expect(axiosMock.history.get[0].params).toEqual({commonsId: undefined, pageNumber: 0, pageSize: 5 });
+    expect(axiosMock.history.get[0].params).toEqual({
+      commonsId: undefined,
+      pageNumber: 0,
+      pageSize: 5,
+    });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-amount`)).toHaveTextContent(
-      "110");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+    ).toHaveTextContent("110");
     expect(
       screen.getByTestId(`${testId}-cell-row-0-col-timestamp`)
     ).toHaveTextContent("2024-06-16");
@@ -69,9 +71,9 @@ describe("PagedProfitsTable tests", () => {
       screen.getByTestId(`${testId}-cell-row-0-col-numCows`)
     ).toHaveTextContent("5");
 
-
-    expect(screen.getByTestId(`${testId}-header-timestamp-sort-carets`)).toHaveTextContent("🔽");
-
+    expect(
+      screen.getByTestId(`${testId}-header-timestamp-sort-carets`)
+    ).toHaveTextContent("🔽");
 
     const nextButton = screen.getByTestId(`${testId}-next-button`);
     expect(nextButton).toBeInTheDocument();
@@ -82,11 +84,12 @@ describe("PagedProfitsTable tests", () => {
     expect(previousButton).toBeDisabled();
   });
 
-   test("buttons are disabled where there are zero pages", async () => {
-
+  test("buttons are disabled where there are zero pages", async () => {
     // arrange
 
-    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.emptyPage);
+    axiosMock
+      .onGet("/api/profits/paged/commonsid")
+      .reply(200, pagedProfitsFixtures.emptyPage);
 
     // act
     render(
@@ -95,7 +98,6 @@ describe("PagedProfitsTable tests", () => {
           <PagedProfitsTable />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
     await waitFor(() => {
@@ -103,7 +105,11 @@ describe("PagedProfitsTable tests", () => {
     });
 
     expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
-    expect(axiosMock.history.get[0].params).toEqual({ commonsId:undefined, pageNumber: 0, pageSize: 5 });
+    expect(axiosMock.history.get[0].params).toEqual({
+      commonsId: undefined,
+      pageNumber: 0,
+      pageSize: 5,
+    });
 
     const nextButton = screen.getByTestId(`${testId}-next-button`);
     expect(nextButton).toBeInTheDocument();
@@ -112,18 +118,21 @@ describe("PagedProfitsTable tests", () => {
     const previousButton = screen.getByTestId(`${testId}-previous-button`);
     expect(previousButton).toBeInTheDocument();
     expect(previousButton).toBeDisabled();
-  }); 
-
-
-
-
+  });
 
   test("renders correct content with multiple pages", async () => {
     // arrange
 
-    axiosMock.onGet("/api/profits/paged/commonsid"   ,{ params: {commonsId: undefined, pageNumber: 0, pageSize: 5 } }   ).reply(200, pagedProfitsFixtures.twoPages[0]);
-    axiosMock.onGet("/api/profits/paged/commonsid" ,{ params: {commonsId: undefined, pageNumber: 1, pageSize: 5 } }     ).reply(200, pagedProfitsFixtures.twoPages[1]);
-
+    axiosMock
+      .onGet("/api/profits/paged/commonsid", {
+        params: { commonsId: undefined, pageNumber: 0, pageSize: 5 },
+      })
+      .reply(200, pagedProfitsFixtures.twoPages[0]);
+    axiosMock
+      .onGet("/api/profits/paged/commonsid", {
+        params: { commonsId: undefined, pageNumber: 1, pageSize: 5 },
+      })
+      .reply(200, pagedProfitsFixtures.twoPages[1]);
 
     // act
     render(
@@ -132,12 +141,11 @@ describe("PagedProfitsTable tests", () => {
           <PagedProfitsTable />
         </MemoryRouter>
       </QueryClientProvider>
-
     );
 
     // assert
-    const expectedHeaders = ['Profit', 'Date', 'Health', 'Cows'];
-    const expectedFields = ['amount', 'timestamp', 'avgCowHealth', 'numCows'];
+    const expectedHeaders = ["Profit", "Date", "Health", "Cows"];
+    const expectedFields = ["amount", "timestamp", "avgCowHealth", "numCows"];
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
@@ -148,17 +156,17 @@ describe("PagedProfitsTable tests", () => {
       expect(axiosMock.history.get.length).toBe(1);
     });
 
-
-
     expectedFields.forEach((field) => {
       const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
 
     expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
-    expect(axiosMock.history.get[0].params).toEqual({ commonsId: undefined, pageNumber: 0, pageSize: 5 });
-
-
+    expect(axiosMock.history.get[0].params).toEqual({
+      commonsId: undefined,
+      pageNumber: 0,
+      pageSize: 5,
+    });
 
     const nextButton = screen.getByTestId(`${testId}-next-button`);
     expect(nextButton).toBeInTheDocument();
@@ -172,34 +180,71 @@ describe("PagedProfitsTable tests", () => {
     expect(screen.getByText(`Page: 1`)).toBeInTheDocument();
 
     expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-amount`)
-      ).toHaveTextContent("20");
+      screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+    ).toHaveTextContent("20");
 
     fireEvent.click(nextButton);
 
-
-    await waitFor(() => {expect(screen.getByText(`Page: 2`)).toBeInTheDocument();});
+    await waitFor(() => {
+      expect(screen.getByText(`Page: 2`)).toBeInTheDocument();
+    });
     expect(previousButton).toBeEnabled();
     expect(nextButton).toBeDisabled();
 
-
     fireEvent.click(previousButton);
-    await waitFor(() => { expect(screen.getByText(`Page: 1`)).toBeInTheDocument();});
+    await waitFor(() => {
+      expect(screen.getByText(`Page: 1`)).toBeInTheDocument();
+    });
     expect(previousButton).toBeDisabled();
-    expect(nextButton).toBeEnabled(); 
+    expect(nextButton).toBeEnabled();
 
-     expect(
-        screen.getByTestId(`${testId}-cell-row-0-col-amount`)
-      ).toHaveTextContent("20"); 
-
-
-
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+    ).toHaveTextContent("20");
   });
   test("renders table with correct layout", async () => {
     // Mock API response
-    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.onePage);
+    axiosMock
+      .onGet("/api/profits/paged/commonsid")
+      .reply(200, pagedProfitsFixtures.onePage);
 
     // Render the component
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <PagedProfitsTable />
+        </MemoryRouter>
+      </QueryClientProvider>
+    );
+
+    // Ensure the element with the specified data-testid is rendered
+    await waitFor(() => {
+      const tableWrapper = screen.getByTestId("PagedProfitsTable-style-inline");
+      expect(tableWrapper).toHaveStyle("display: inline-block");
+    });
+  });
+  test("Values are formatted and aligned correctly", () => {
+    const queryClient = new QueryClient();
+    
+    // Mock the backend response
+    const mockContent = {
+        content: [{
+            amount: 100.00,
+            timestamp: "2024-11-26T12:00:00",
+            avgCowHealth: 95.00,
+            numCows: 10
+        }],
+        totalPages: 1
+    };
+
+    // Mock the useBackend hook
+    const mockUseBackend = jest.spyOn(require("main/utils/useBackend"), "useBackend");
+    mockUseBackend.mockReturnValue({
+        data: mockContent,
+        error: null,
+        isLoading: false
+    });
+
     render(
         <QueryClientProvider client={queryClient}>
             <MemoryRouter>
@@ -208,12 +253,34 @@ describe("PagedProfitsTable tests", () => {
         </QueryClientProvider>
     );
 
-    // Ensure the element with the specified data-testid is rendered
-    await waitFor(() => {
-        const tableWrapper = screen.getByTestId("PagedProfitsTable-style-inline");
-        expect(tableWrapper).toHaveStyle("display: inline-block");
+    const expectedHeaders = [
+        "Profit",
+        "Date",
+        "Health",
+        "Cows"
+    ];
+
+    expectedHeaders.forEach((headerText) => {
+        const header = screen.getByText(headerText);
+        expect(header).toBeInTheDocument();
     });
-  });
 
+    // Test content and alignment 
+    const testId = "PagedProfitsTable";
 
+    // Get the cells by testid
+    const amountCell = screen.getByTestId(`${testId}-cell-row-0-col-amount`);
+    const healthCell = screen.getByTestId(`${testId}-cell-row-0-col-avgCowHealth`);
+    const cowsCell = screen.getByTestId(`${testId}-cell-row-0-col-numCows`);
+
+    // Check content
+    expect(amountCell).toHaveTextContent("$100.00");
+    expect(healthCell).toHaveTextContent("95.00%");
+    expect(cowsCell).toHaveTextContent("10");
+
+    // Check alignment
+    expect(amountCell.firstChild).toHaveStyle("text-align: right");
+    expect(healthCell.firstChild).toHaveStyle("text-align: right");
+    expect(cowsCell.firstChild).toHaveStyle("text-align: right");
+});
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
This ticket completes ticket 38 and makes the profit table in the commons page all numeric values right aligned.

## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="594" alt="Screenshot 2024-11-26 at 4 56 13 PM" src="https://github.com/user-attachments/assets/56a445ce-3df4-4202-a6aa-10b30a2a809d">

Dokku: 
https://proj-happycows-f24-09-elijahelephant-dev.dokku-09.cs.ucsb.edu/

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project
3. Join a commons, buy cows, milk them
4. check right aligment in the table

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #38
