### PR TITLE
fix the profit table skryker expectaiton

### DIFF
--- a/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
@@ -287,30 +287,4 @@ describe("PagedProfitsTable tests", () => {
         "text-align: right;"
     );
 });
-test("shows expected headers and fields for ProfitsTable", () => {
-      render(<ProfitsTable profits= {profitsFixtures.threeProfits} />);
-
-      const headers = ["Profit", "Date", "Health", "Cows"];
-      const testId = "ProfitsTable";
-
-
-      headers.forEach((header) => {
-        expect(screen.getByText(header)).toBeInTheDocument();
-      });
-
-      const firstProfit = profitsFixtures.threeProfits[0];
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-Profit`)).toHaveTextContent(
-        `$${firstProfit.amount.toFixed(2)}`
-      );
-
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-date`)).toBeInTheDocument(); 
-
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-Health`)).toHaveTextContent(
-        `${firstProfit.avgCowHealth}%`
-      );
-
-      expect(screen.getByTestId(`${testId}-cell-row-0-col-numCows`)).toBeInTheDocument(
-        firstProfit.numCows.toString()
-      );
-    });
 });

--- a/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
@@ -287,4 +287,30 @@ describe("PagedProfitsTable tests", () => {
         "text-align: right;"
     );
 });
+test("shows expected headers and fields for ProfitsTable", () => {
+      render(<ProfitsTable profits= {profitsFixtures.threeProfits} />);
+
+      const headers = ["Profit", "Date", "Health", "Cows"];
+      const testId = "ProfitsTable";
+
+
+      headers.forEach((header) => {
+        expect(screen.getByText(header)).toBeInTheDocument();
+      });
+
+      const firstProfit = profitsFixtures.threeProfits[0];
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-Profit`)).toHaveTextContent(
+        `$${firstProfit.amount.toFixed(2)}`
+      );
+
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-date`)).toBeInTheDocument(); 
+
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-Health`)).toHaveTextContent(
+        `${firstProfit.avgCowHealth}%`
+      );
+
+      expect(screen.getByTestId(`${testId}-cell-row-0-col-numCows`)).toBeInTheDocument(
+        firstProfit.numCows.toString()
+      );
+    });
 });

--- a/frontend/src/tests/components/Commons/ProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/ProfitsTable.test.js
@@ -25,4 +25,30 @@ describe("ProfitsTable tests", () => {
         });
 
     });
+    test("shows expected headers and fields for ProfitsTable", () => {
+        render(<ProfitsTable profits= {profitsFixtures.threeProfits} />);
+  
+        const headers = ["Profit", "Date", "Health", "Cows"];
+        const testId = "ProfitsTable";
+  
+  
+        headers.forEach((header) => {
+          expect(screen.getByText(header)).toBeInTheDocument();
+        });
+  
+        const firstProfit = profitsFixtures.threeProfits[0];
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-Profit`)).toHaveTextContent(
+          `$${firstProfit.amount.toFixed(2)}`
+        );
+  
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-date`)).toBeInTheDocument(); 
+  
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-Health`)).toHaveTextContent(
+          `${firstProfit.avgCowHealth}%`
+        );
+  
+        expect(screen.getByTestId(`${testId}-cell-row-0-col-numCows`)).toBeInTheDocument(
+          firstProfit.numCows.toString()
+        );
+      });
 });


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I find stryker exceptions and remove it by writing effective tests.

## Screenshots (Optional)
Before tests:
![621732614997_ pic](https://github.com/user-attachments/assets/87c70113-209d-4b94-9f1d-cb51d4616d4f)
After tests:
![651732642326_ pic](https://github.com/user-attachments/assets/4282d2c4-510a-4005-950f-0cf9273b6759)



## Validation (Optional)
1. Download this branch.
2. run npm test
3. run npx stryker run -m src/main/components/Commons/ProfitsTable.js
## Tests
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
Closes #65 